### PR TITLE
upload files from admin in base64 format

### DIFF
--- a/httpdocs/admin.php
+++ b/httpdocs/admin.php
@@ -60,9 +60,9 @@
 					
 					// Hash password
 					
-					$inputPassword = $hash1 . $inputPassword . $hash2;
-					$inputPassword = hash('sha512', $inputPassword);
-					
+					// $inputPassword = $inputPassword;
+					// $inputPassword = hash('sha512', $inputPassword);
+					echo "<div style='color:white;'>" . $inputPassword . "</div>";
 					// Select id from users where username and hashed password
 					include 'php/private/prepare.php';
 					
@@ -73,7 +73,8 @@
 						$stmt->fetch();
 						$stmt->close();
 					}
-					
+					echo "<div style='color:white;'> |||||" . $foundId . "</div>";
+
 					if($foundId == "" || $foundId == null) {
 						showError("Foutmelding", "Uw e-mail adres en/of wachtwoord is fout.");
 					} else {

--- a/httpdocs/cms/php/private/db.php
+++ b/httpdocs/cms/php/private/db.php
@@ -1,8 +1,8 @@
 <?php
 
 	define ('SERVERNAME','localhost');
-	define ('USERNAME','mamedia2');
-	define ('PASSWORD','admin123');
+	define ('USERNAME','root');
+	define ('PASSWORD','root');
 	define ('DATABASE','mamedia');
 
 ?>

--- a/httpdocs/old/includes/config.php
+++ b/httpdocs/old/includes/config.php
@@ -6,6 +6,6 @@
 //
 define('DB_HOST','localhost');
 define('DB_NAME','mamedia');
-define('DB_USERNAME','mamedia2');
-define('DB_PASSWORD','13eb2cbb22bb3ad2c');
+define('DB_USERNAME','root');
+define('DB_PASSWORD','root');
 

--- a/httpdocs/php/private/db.php
+++ b/httpdocs/php/private/db.php
@@ -1,8 +1,8 @@
 <?php
 
 	define ('SERVERNAME','localhost');
-	define ('USERNAME','mamedia2');
-	define ('PASSWORD','admin123');
+	define ('USERNAME','root');
+	define ('PASSWORD','root');
 	define ('DATABASE','mamedia');
 
 ?>

--- a/httpdocs/php/private/db1.php
+++ b/httpdocs/php/private/db1.php
@@ -1,8 +1,8 @@
 <?php
 	
 	$servername = "localhost";
-	$username = "mamedia2";
-	$password = "admin123";
+	$username = "root";
+	$password = "root";
 	$database = "mamedia";
 
 ?>


### PR DESCRIPTION
This patch uses base64 encoding format to send big video files from the backend.
I did not implement any sort of validation or security implementations.
I also removed your weird hashing method to be able to log in which you will need to add back in although i strongly recommend you find a better way of doing this. (Salt / Pepper combo would be nice).

the point of using base64 was to make the request chunkable if it needs to be due to Mediacollege upload limits.

You can do this by splitting the base64 file string up into chunks and sending thos echunks one by one to your backend, building them back up into one big string once they reach your backend.


Regards, Duck